### PR TITLE
WIP: CloudEvent as a payload for SSE (RestEasy Reactive)

### DIFF
--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Endpoint.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Endpoint.java
@@ -18,7 +18,7 @@ public interface Endpoint {
   @RestStreamElementType(JsonFormat.CONTENT_TYPE)
   @Produces(MediaType.SERVER_SENT_EVENTS)
   @Path("events")
-  Multi<byte[]> events();
+  Multi<CloudEvent> events();
 
   @POST
   @Consumes

--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
@@ -3,7 +3,6 @@ package com.redhat.openshift.knative.showcase.events;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cloudevents.CloudEvent;
-import io.cloudevents.jackson.JsonFormat;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -25,11 +24,6 @@ class Presenter {
   @Inject
   Presenter(ObjectMapper mapper) {
     this.mapper = mapper;
-  }
-
-  byte[] asJson(CloudEvent ce) {
-    var serializer = new JsonFormat();
-    return serializer.serialize(ce);
   }
 
   CharSequence asHumanReadable(CloudEvent ce) {

--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Rest.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Rest.java
@@ -23,9 +23,8 @@ class Rest implements Endpoint {
   }
 
   @Override
-  public Multi<byte[]> events() {
-    return events.stream()
-      .map(this::workaroundQuarkus31587);
+  public Multi<CloudEvent> events() {
+    return events.stream();
   }
 
   @Override
@@ -40,14 +39,4 @@ class Rest implements Endpoint {
     receive(event);
   }
 
-  /**
-   * A workaround for
-   * <a href="https://github.com/quarkusio/quarkus/issues/31587">quarkusio/quarkus#31587</a>
-   * and <a href="https://github.com/cloudevents/sdk-java/issues/533">cloudevents/sdk-java#533</a>.
-   *
-   * TODO: Remove this method once the above issues is fixed.
-   */
-  private byte[] workaroundQuarkus31587(CloudEvent event) {
-    return presenter.asJson(event);
-  }
 }

--- a/quarkus/src/test/java/com/redhat/openshift/knative/showcase/events/EndpointTest.java
+++ b/quarkus/src/test/java/com/redhat/openshift/knative/showcase/events/EndpointTest.java
@@ -1,17 +1,18 @@
 package com.redhat.openshift.knative.showcase.events;
 
 import io.cloudevents.core.builder.CloudEventBuilder;
-import io.cloudevents.jackson.JsonFormat;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,12 +27,11 @@ class EndpointTest {
   }
 
   @Test
+  @Timeout(value = 1, unit = TimeUnit.MINUTES)
   void events() throws ExecutionException, InterruptedException {
     var id = UUID.randomUUID();
     sendEvent(id.toString());
-    var serializer = new JsonFormat();
     var collected = client.events()
-      .map(serializer::deserialize)
       .capDemandsTo(1)
       .collect()
       .first()


### PR DESCRIPTION
quarkusio/quarkus#31587 is supposed to be fixed, but as one may see in this PR, but it is not.

Exception thrown:

```
2023-07-24 23:28:51,293 ERROR [io.qua.ver.cor.run.VertxCoreRecorder] (vert.x-eventloop-thread-2) Uncaught exception received by Vert.x: io.cloudevents.rw.CloudEventRWException: Could not parse. Unknown encoding. Invalid content type or spec version
	at io.cloudevents.rw.CloudEventRWException.newUnknownEncodingException(CloudEventRWException.java:201)
	at io.cloudevents.core.message.impl.MessageUtils.parseStructuredOrBinaryMessage(MessageUtils.java:80)
	at io.cloudevents.http.restful.ws.impl.RestfulWSMessageFactory.create(RestfulWSMessageFactory.java:34)
	at io.cloudevents.http.restful.ws.CloudEventsProvider.readFrom(CloudEventsProvider.java:68)
	at io.cloudevents.http.restful.ws.CloudEventsProvider.readFrom(CloudEventsProvider.java:51)
	at org.jboss.resteasy.reactive.client.impl.ClientReaderInterceptorContextImpl.proceed(ClientReaderInterceptorContextImpl.java:86)
	at org.jboss.resteasy.reactive.client.impl.ClientSerialisers.invokeClientReader(ClientSerialisers.java:160)
	at org.jboss.resteasy.reactive.client.impl.InboundSseEventImpl.readData(InboundSseEventImpl.java:123)
	at org.jboss.resteasy.reactive.client.impl.InboundSseEventImpl.readData(InboundSseEventImpl.java:111)
	at org.jboss.resteasy.reactive.client.impl.MultiInvoker.lambda$registerForSse$2(MultiInvoker.java:166)
	at org.jboss.resteasy.reactive.client.impl.SseEventSourceImpl.fireEvent(SseEventSourceImpl.java:224)
	at org.jboss.resteasy.reactive.client.impl.SseParser.dispatchEvent(SseParser.java:167)
	at org.jboss.resteasy.reactive.client.impl.SseParser.parseEvent(SseParser.java:138)
	at org.jboss.resteasy.reactive.client.impl.SseParser.handle(SseParser.java:108)
	at org.jboss.resteasy.reactive.client.impl.SseParser.handle(SseParser.java:11)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264)
	at io.vertx.core.http.impl.HttpEventHandler.handleChunk(HttpEventHandler.java:51)
	at io.vertx.core.http.impl.HttpClientResponseImpl.handleChunk(HttpClientResponseImpl.java:239)
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.lambda$new$0(Http1xClientConnection.java:452)
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:255)
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:134)
	at io.vertx.core.http.impl.Http1xClientConnection$StreamImpl.handleChunk(Http1xClientConnection.java:704)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:76)
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:153)
	at io.vertx.core.http.impl.Http1xClientConnection.handleResponseChunk(Http1xClientConnection.java:918)
	at io.vertx.core.http.impl.Http1xClientConnection.handleHttpMessage(Http1xClientConnection.java:811)
	at io.vertx.core.http.impl.Http1xClientConnection.handleMessage(Http1xClientConnection.java:778)
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:158)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
